### PR TITLE
Add startup probe to health check

### DIFF
--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
@@ -85,7 +85,7 @@ func NewServer(c *proxy.Client, port string) (*Server, error) {
 	})
 
 	mux.HandleFunc(livenessPath, func(w http.ResponseWriter, _ *http.Request) {
-		if !isLive() { // Because isLive() returns true, this case should not be reached.
+		if !isLive() { // Because isLive() always returns true, this case should not be reached.
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte("error"))
 			return

--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
@@ -67,6 +67,7 @@ func NewServer(c *proxy.Client, port string) (*Server, error) {
 		if !hcServer.proxyStarted() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte("error"))
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))

--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
@@ -34,11 +34,11 @@ const (
 
 // Server is a type used to implement health checks for the proxy.
 type Server struct {
-	// started is a channel used to indicate whether the proxy has finished 
-	// starting up. The channel is open when startup is in progress and
-	// closed when startup is complete.
+	// started is used to indicate whether the proxy has finished starting up. 
+	// If started is open, startup has not finished. If started is closed,
+	// startup is complete.
 	started chan struct{}
-	// once ensures that started can only closed once.
+	// once ensures that started can only be closed once.
 	once *sync.Once
 	// port designates the port number on which Server listens and serves.
 	port string
@@ -117,7 +117,7 @@ func (s *Server) NotifyStarted() {
 	s.once.Do(func() { close(s.started) })
 }
 
-// proxyStarted returns true if started is closed, false otherwise
+// proxyStarted returns true if started is closed, false otherwise.
 func (s *Server) proxyStarted() bool {
 	select {
 	case <- s.started:

--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck.go
@@ -99,7 +99,7 @@ func NewServer(c *proxy.Client, port string) (*Server, error) {
 	
 	go func() {
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logging.Errorf("Failed to started health check HTTP server: %v", err)
+			logging.Errorf("Failed to start health check HTTP server: %v", err)
 		}
 	}()
 

--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck_test.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	startupPath = "/startup"
 	livenessPath  = "/liveness"
 	readinessPath = "/readiness"
 	testPort      = "8090"
@@ -57,12 +58,20 @@ func TestStartupFail(t *testing.T) {
 	}
 	defer s.Close(context.Background())
 
-	resp, err := http.Get("http://localhost:" + testPort + readinessPath)
+	resp, err := http.Get("http://localhost:" + testPort + startupPath)
 	if err != nil {
 		t.Fatalf("HTTP GET failed: %v\n", err)
 	}
 	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Errorf("Got status code %v instead of %v", resp.StatusCode, http.StatusServiceUnavailable)
+		t.Errorf("%v returned status code %v instead of %v", startupPath, resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	resp, err = http.Get("http://localhost:" + testPort + readinessPath)
+	if err != nil {
+		t.Fatalf("HTTP GET failed: %v\n", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("%v returned status code %v instead of %v", readinessPath, resp.StatusCode, http.StatusServiceUnavailable)
 	}
 }
 
@@ -78,12 +87,20 @@ func TestStartupPass(t *testing.T) {
 	// Simulate the proxy client completing startup.
 	s.NotifyStarted()
 
-	resp, err := http.Get("http://localhost:" + testPort + readinessPath)
+	resp, err := http.Get("http://localhost:" + testPort + startupPath)
 	if err != nil {
 		t.Fatalf("HTTP GET failed: %v\n", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Got status code %v instead of %v", resp.StatusCode, http.StatusOK)
+		t.Errorf("%v returned status code %v instead of %v", startupPath, resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.Get("http://localhost:" + testPort + readinessPath)
+	if err != nil {
+		t.Fatalf("HTTP GET failed: %v\n", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("%v returned status code %v instead of %v", readinessPath, resp.StatusCode, http.StatusOK)
 	}
 }
 

--- a/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck_test.go
+++ b/cmd/cloud_sql_proxy/internal/healthcheck/healthcheck_test.go
@@ -49,7 +49,7 @@ func TestLiveness(t *testing.T) {
 	}
 }
 
-// Test to verify that when startup has NOT finished, the readiness endpoint writes 
+// Test to verify that when startup has NOT finished, the startup and readiness endpoints write
 // http.StatusServiceUnavailable.
 func TestStartupFail(t *testing.T) {
 	s, err := healthcheck.NewServer(&proxy.Client{}, testPort)
@@ -76,7 +76,7 @@ func TestStartupFail(t *testing.T) {
 }
 
 // Test to verify that when startup HAS finished (and MaxConnections limit not specified), 
-// the readiness endpoint writes http.StatusOK.
+// the startup and readiness endpoints write http.StatusOK.
 func TestStartupPass(t *testing.T) {
 	s, err := healthcheck.NewServer(&proxy.Client{}, testPort)
 	if err != nil {


### PR DESCRIPTION
## Change Description

Add an endpoint that checks the status of the proxy client's startup. In Kubernetes, this endpoint will communicate with the startup probe.
